### PR TITLE
Remove "internal use" blobs from the lookup results

### DIFF
--- a/src/itkach/aard2/BlobListAdapter.java
+++ b/src/itkach/aard2/BlobListAdapter.java
@@ -49,7 +49,7 @@ public class BlobListAdapter extends BaseAdapter {
         synchronized (list) {
             list.clear();
         }
-        this.iter = lookupResultsIter;
+        this.iter = new BlobListFilter(lookupResultsIter);
         loadChunkSync();
     }
 

--- a/src/itkach/aard2/BlobListFilter.java
+++ b/src/itkach/aard2/BlobListFilter.java
@@ -1,0 +1,82 @@
+package itkach.aard2;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import itkach.slob.Slob.Blob;
+
+/**
+ * Iterator that filters out blobs that are not supposed to be user-visible (internal dictionary resources).
+ */
+class BlobListFilter implements Iterator<Blob> {
+    private static final Set<String> USER_VISIBLE_TYPES = new HashSet<String>(Arrays.asList(
+            "text/html",
+            "text/plain"
+    ));
+
+    private final Iterator<Blob> delegate;
+    private Blob next;
+
+    BlobListFilter(Iterator<Blob> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return peek() != null;
+    }
+
+    @Override
+    public Blob next() {
+        Blob next = peek();
+        if (next != null) {
+            this.next = null;
+            return next;
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    private Blob peek() {
+        if (next == null) {
+            next = findNext();
+        }
+        return next;
+    }
+
+    private Blob findNext() {
+        while (delegate.hasNext()) {
+            Blob next = delegate.next();
+            if (shouldBlobBeVisible(next)) {
+                return next;
+            }
+        }
+        return null;
+    }
+
+    private boolean shouldBlobBeVisible(Blob blob) {
+        // Getting the content type requires I/O, so only do it if the key starts with "~/"
+        // which is the prefix used by the standard dictionary generators for storing resources.
+        return !blob.key.startsWith("~/") || isUserVisibleType(blob.getContentType());
+    }
+
+    private static boolean isUserVisibleType(String type) {
+        return type != null && USER_VISIBLE_TYPES.contains(normalizeType(type));
+    }
+
+    private static String normalizeType(String type) {
+        int i = type.indexOf(';');
+        if (i > 0) {
+            type = type.substring(0, i);
+        }
+        return type;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
I hope the commit message is self-explanatory:
```
The dictionary generators add "internal" resources to the slob file
using key names such as "~/css/default.css". These are for internal use
and should not be made visible in the lookup results.

This commit introduces a filter to remove those: any blob that has a
content type which is not HTML or plain text is filtered out. However,
since retrieving the content type requires performing I/O, for
efficiency reasons the content type check is only done if the key
starts with the prefix "~/" — any other key is assumed to be "public".
Although the standard dictionary generators do not add "public" content
under the "~/" prefix, filtering is not based only on key alone to
avoid affecting existing dictionaries that were created using a
different toolchain.
```