### PR TITLE
Added link sharing functionality (#103)

### DIFF
--- a/res/menu/article.xml
+++ b/res/menu/article.xml
@@ -40,4 +40,10 @@
           android:showAsAction="never"
         />
 
+    <item android:id="@+id/action_share_link"
+        android:title="@string/action_share_link"
+        android:enabled="false"
+        android:showAsAction="never"
+        />
+
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="action_select_style">Style...</string>
     <string name="select_style">Select style</string>
     <string name="default_style_title">Default</string>
+    <string name="action_share_link">Share link</string>
     <string name="subtitle_settings">Settings</string>
     <string name="setting_remote_content_always">Always</string>
     <string name="setting_remote_content_wifi">When on Wi-Fi</string>

--- a/src/itkach/aard2/ArticleWebView.java
+++ b/src/itkach/aard2/ArticleWebView.java
@@ -104,7 +104,7 @@ public class ArticleWebView extends SearchableWebView {
         this(context, null);
     }
 
-    public ArticleWebView(Context context, AttributeSet attrs) {
+    public ArticleWebView(final Context context, AttributeSet attrs) {
         super(context, attrs);
 
         connectivityManager = (ConnectivityManager) context
@@ -267,7 +267,7 @@ public class ArticleWebView extends SearchableWebView {
                         share.setType("text/plain");
                         share.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
                         share.putExtra(Intent.EXTRA_TEXT, url);
-                        getContext().startActivity(Intent.createChooser(share, "Share Link"));
+                        getContext().startActivity(Intent.createChooser(share, context.getString(R.string.action_share_link)));
                         return true;
                     }
                 }

--- a/src/itkach/aard2/FragmentRunnable.java
+++ b/src/itkach/aard2/FragmentRunnable.java
@@ -1,0 +1,11 @@
+package itkach.aard2;
+
+import android.support.v4.app.Fragment;
+
+public abstract class FragmentRunnable implements Runnable {
+    protected Fragment fragment;
+
+    FragmentRunnable(Fragment fragment) {
+        this.fragment = fragment;
+    }
+}


### PR DESCRIPTION
Hi,

I've decided to add "Share link" functionality, raised in issue #103. I know there is already a possibility to share any link from the entry by long-pressing it. Still, this functionality is not very obvious (I've learned about it from the code even though I was using the app for some time), and I thought a separate "Share" button could be useful.

The implementation is based on downloading the dictionary entry in the background and searching for an anchor tag with `id="view-online-link"`. All dictionaries made out of MediaWiki have an original link with such id. From what I've seen in the dictionaries list, most of them are from MediaWiki pages, and those that aren't, don't contain any other reference to the original. Of course, if, with some time, slob files would keep a reference to the original resource, it can be rewritten, but from what I've found out while using the Python's slob tool, dictionaries don't keep such metadata for entries.

I hope you like it, and if you have any comments on the code, I can fix it (I haven't programmed in Java for years, so I could do something wrong).