### PR TITLE
fix package visibility for custom text selection actions

### DIFF
--- a/AndroidManifest.template.xml
+++ b/AndroidManifest.template.xml
@@ -4,6 +4,14 @@
     android:versionCode="56"
     android:versionName="0.56" >
 
+    <queries>
+        <intent>
+            <action
+                android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,14 @@
     android:versionCode="56"
     android:versionName="0.56" >
 
+    <queries>
+        <intent>
+            <action
+                android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 


### PR DESCRIPTION
https://developer.android.com/training/package-visibility/use-cases#custom-text-selection-actions

so that we can long press a word to search/read it (by 3rd part app)