### PR TITLE
Add tap to translate

### DIFF
--- a/src/itkach/aard2/ArticleWebView.java
+++ b/src/itkach/aard2/ArticleWebView.java
@@ -10,6 +10,7 @@ import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -466,7 +467,10 @@ public class ArticleWebView extends SearchableWebView {
     @JavascriptInterface
     public void onWordTapped(String tappedWord) {
         Log.d(TAG, "Word tapped! " + tappedWord);
-        Application.get().lookupAsync(tappedWord);
+        
+        if(!TextUtils.isEmpty()) {
+            Application.get().lookupAsync(tappedWord);
+        }
     }
 
     void applyStylePref() {


### PR DESCRIPTION
Currently in order to translate a word that appears in the article view you need to long tap, wait 1 second, wait for the selection context menu to appear, in the list of items pick three dots and then locate and tap `Aard 2` — this is tedious and requires too much effort.

The PR allows firing a lookup on a short single tap on a word.